### PR TITLE
reparar error de migraciones

### DIFF
--- a/database/migrations/2017_06_03_125700_campos_nulos_en_products.php
+++ b/database/migrations/2017_06_03_125700_campos_nulos_en_products.php
@@ -24,7 +24,7 @@ class CamposNulosEnProducts extends Migration {
 			$table->string('weight')->nullable()->change();
 			$table->string('type')->nullable()->change();
 			$table->string('unit')->nullable()->change();
-			$table->mediumText('details')->nullable()->change();
+			$table->text('details')->nullable()->change();
 		});
 	}
 


### PR DESCRIPTION
`mediumText()` no es un método disponible en las migraciones de
Laravel 5.0