### PR TITLE
incluir sku en info de artículo en el cart

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -5,6 +5,7 @@ use papeleria\products;
 if ( ! function_exists('add_to_cart_button')) {
   function add_to_cart_button(products $product) {
     $id    = $product->id;
+    $sku   = $product->sku;
     $name  = $product->name;
     $price = $product->price;
     $token = csrf_token();
@@ -16,6 +17,7 @@ if ( ! function_exists('add_to_cart_button')) {
   </button>
   <form class="count-input" hidden>
     <input type="hidden" name="product[id]" value="{$id}">
+    <input type="hidden" name="product[sku]" value="{$sku}">
     <input type="hidden" name="product[nombre]" value="{$name}">
     <input type="hidden" name="product[precio_unitario]" value="{$price}">
     <input type="hidden" name="_token" value="{$token}">


### PR DESCRIPTION
Como el campo `articulos` de la tabla `pedidos` se llena con la
misma info que los productos del cart, incluir el sku de los
artículos en el cart hará que también se incluya en el json que
se guarda en la base de datos al crear un pedido nuevo.